### PR TITLE
Add yarn update-schema script

### DIFF
--- a/api/graphql.ts
+++ b/api/graphql.ts
@@ -3,7 +3,15 @@
 
 import type { Request } from "express";
 import { graphqlHTTP } from "express-graphql";
-import { formatError, GraphQLObjectType, GraphQLSchema } from "graphql";
+import fs from "fs";
+import {
+  formatError,
+  GraphQLObjectType,
+  GraphQLSchema,
+  printSchema,
+} from "graphql";
+import { noop } from "lodash";
+import path from "path";
 import { reportError } from "../core";
 import env from "../env";
 import { Context } from "./context";
@@ -12,6 +20,9 @@ import * as queries from "./queries";
 import { nodeField, nodesField } from "./types/node";
 import { ValidationError } from "./utils";
 
+/**
+ * GraphQL API schema.
+ */
 export const schema = new GraphQLSchema({
   query: new GraphQLObjectType({
     name: "Root",
@@ -48,3 +59,9 @@ export const graphql = graphqlHTTP((req, res, params) => ({
     return formatError(err);
   },
 }));
+
+export function updateSchema(cb: fs.NoParamCallback = noop): void {
+  const file = path.resolve(__dirname, "../schema.graphql");
+  const output = printSchema(schema, { commentDescriptions: true });
+  fs.writeFile(file, output, { encoding: "utf-8" }, cb);
+}

--- a/api/index.ts
+++ b/api/index.ts
@@ -6,7 +6,7 @@ import express from "express";
 import { NotFound } from "http-errors";
 import { auth } from "../auth";
 import { handleError } from "./errors";
-import { graphql } from "./graphql";
+import { graphql, updateSchema } from "./graphql";
 import { withViews } from "./views";
 
 export const api = withViews(express());
@@ -40,6 +40,8 @@ api.use(handleError);
  * NOTE: This block will be removed from production build by Rollup.
  */
 if (process.env.NODE_ENV === "development") {
+  updateSchema();
+
   const port = process.env.PORT ?? 8080;
   const envName = chalk.greenBright(process.env.APP_ENV);
   const dbName = chalk.greenBright(process.env.PGDATABASE);

--- a/api/types/picture.ts
+++ b/api/types/picture.ts
@@ -1,0 +1,16 @@
+/* SPDX-FileCopyrightText: 2016-present Kriasoft <hello@kriasoft.com> */
+/* SPDX-License-Identifier: MIT */
+
+import { GraphQLObjectType, GraphQLString } from "graphql";
+import type { Identity } from "../../db";
+import { Context } from "../context";
+
+export const PictureType = new GraphQLObjectType<Identity, Context>({
+  name: "Picture",
+
+  fields: {
+    url: {
+      type: GraphQLString,
+    },
+  },
+});

--- a/api/types/user.ts
+++ b/api/types/user.ts
@@ -14,6 +14,7 @@ import { Context } from "../context";
 import { dateField } from "./fields";
 import { IdentityType } from "./identity";
 import { nodeInterface } from "./node";
+import { PictureType } from "./picture";
 
 export const UserType = new GraphQLObjectType<User, Context>({
   name: "User",
@@ -50,7 +51,7 @@ export const UserType = new GraphQLObjectType<User, Context>({
     },
 
     picture: {
-      type: GraphQLString,
+      type: PictureType,
     },
 
     timeZone: {

--- a/auth/state.ts
+++ b/auth/state.ts
@@ -5,7 +5,7 @@ import jwt from "jsonwebtoken";
 
 const secret = "~vD3m!st#`K~A;8.";
 
-type State = { [key: string]: string };
+type State = { [key: string]: string | number };
 
 /**
  * Creates an OAuth 2.0 state string using JWT.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "db:backup": "node ./scripts/db-backup",
     "db:restore": "node ./scripts/db-restore",
     "db:repl": "node --experimental-repl-await ./scripts/repl",
+    "update-schema": "node ./scripts/update-schema",
     "update-types": "node ./scripts/update-types",
     "psql": "node ./scripts/psql",
     "repl": "node --experimental-repl-await ./scripts/repl",

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,0 +1,133 @@
+schema {
+  query: Root
+  mutation: Mutation
+}
+
+# The top-level API
+type Root {
+  # Fetches an object given its ID
+  node(
+    # The ID of an object
+    id: ID!
+  ): Node
+
+  # Fetches objects given their IDs
+  nodes(
+    # The IDs of objects
+    ids: [ID!]!
+  ): [Node]!
+
+  # The authenticated user.
+  me: User
+
+  # Find user by username or email.
+  user(username: String, email: String): User
+  users(after: String, first: Int): UserConnection
+}
+
+# An object with an ID
+interface Node {
+  # The id of the object.
+  id: ID!
+}
+
+# The registered user account.
+type User implements Node {
+  # The ID of an object
+  id: ID!
+  username: String
+  email: String
+  emailVerified: Boolean
+  name: String
+  picture: Picture
+  timeZone: String
+  locale: String
+  identities: [Identity!]
+  createdAt(format: String): String
+  updatedAt(format: String): String
+  lastLogin(format: String): String
+}
+
+type Picture {
+  url: String
+}
+
+# The OAuth user identity (credentials).
+type Identity {
+  id: ID!
+  provider: IdentityProvider!
+  email: String
+}
+
+# OAuth identity provider.
+enum IdentityProvider {
+  Google
+  Apple
+  Facebook
+  GitHub
+  LinkedIn
+  Microsoft
+  Twitter
+  Yahoo
+  GameCenter
+  PlayGames
+}
+
+# A connection to a list of items.
+type UserConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # A list of edges.
+  edges: [UserEdge]
+  totalCount: Int!
+}
+
+# Information about pagination in a connection.
+type PageInfo {
+  # When paginating forwards, are there more items?
+  hasNextPage: Boolean!
+
+  # When paginating backwards, are there more items?
+  hasPreviousPage: Boolean!
+
+  # When paginating backwards, the cursor to continue.
+  startCursor: String
+
+  # When paginating forwards, the cursor to continue.
+  endCursor: String
+}
+
+# An edge in a connection.
+type UserEdge {
+  # The item at the end of the edge
+  node: User
+
+  # A cursor for use in pagination
+  cursor: String!
+}
+
+type Mutation {
+  # Clears authentication session.
+  signOut: String
+
+  # Updates the user account.
+  updateUser(
+    input: UpdateUserInput
+    dryRun: Boolean! = false
+  ): UpdateUserPayload
+}
+
+type UpdateUserPayload {
+  user: User
+}
+
+input UpdateUserInput {
+  id: ID!
+  username: String
+  email: String
+  name: String
+  picture: String
+  timeZone: String
+  locale: String
+}

--- a/scripts/update-schema.js
+++ b/scripts/update-schema.js
@@ -1,0 +1,19 @@
+/* SPDX-FileCopyrightText: 2016-present Kriasoft <hello@kriasoft.com> */
+/* SPDX-License-Identifier: MIT */
+
+// Load environment variables (PGHOST, PGUSER, etc.)
+require("../env/config");
+// Allow to import TypeScript files compiled on the fly via Babel
+require("@babel/register")({ extensions: [".ts"], cache: false });
+
+const { updateSchema } = require("../api/graphql");
+
+/**
+ * Generates `schema.graphql` file from the actual GraphQL schema.
+ */
+updateSchema((err) => {
+  if (err) {
+    console.err(err);
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
- Add `Picture` GraphQL type representing an image/media asset
- Add `yarn update-schema` script that generates GraphQL API schema from the code
- Automatically update `schema.graphql` in the root of the project on code changes